### PR TITLE
fix: parsing comment and CDATA and implement auto buffer grow max limit

### DIFF
--- a/internal/gpx/schema/extensions.go
+++ b/internal/gpx/schema/extensions.go
@@ -47,31 +47,31 @@ func (t *TrackPointExtension) UnmarshalToken(tok *xmltokenizer.Tokenizer, se *xm
 
 		switch string(token.Name.Local) {
 		case "cad", "cadence":
-			val, err := strconv.ParseUint(string(token.CharData), 10, 8)
+			val, err := strconv.ParseUint(string(token.Data), 10, 8)
 			if err != nil {
 				return err
 			}
 			t.Cadence = uint8(val)
 		case "distance":
-			val, err := strconv.ParseFloat(string(token.CharData), 64)
+			val, err := strconv.ParseFloat(string(token.Data), 64)
 			if err != nil {
 				return err
 			}
 			t.Distance = val
 		case "hr", "heartrate":
-			val, err := strconv.ParseUint(string(token.CharData), 10, 8)
+			val, err := strconv.ParseUint(string(token.Data), 10, 8)
 			if err != nil {
 				return err
 			}
 			t.HeartRate = uint8(val)
 		case "atemp", "temp", "temperature":
-			val, err := strconv.ParseInt(string(token.CharData), 10, 8)
+			val, err := strconv.ParseInt(string(token.Data), 10, 8)
 			if err != nil {
 				return err
 			}
 			t.Temperature = int8(val)
 		case "power":
-			val, err := strconv.ParseUint(string(token.CharData), 10, 16)
+			val, err := strconv.ParseUint(string(token.Data), 10, 16)
 			if err != nil {
 				return err
 			}

--- a/internal/gpx/schema/metadata.go
+++ b/internal/gpx/schema/metadata.go
@@ -37,9 +37,9 @@ func (m *Metadata) UnmarshalToken(tok *xmltokenizer.Tokenizer, se *xmltokenizer.
 
 		switch string(token.Name.Local) {
 		case "name":
-			m.Name = string(token.CharData)
+			m.Name = string(token.Data)
 		case "desc":
-			m.Desc = string(token.CharData)
+			m.Desc = string(token.Data)
 		case "author":
 			m.Author = new(Author)
 			se := xmltokenizer.GetToken().Copy(token)
@@ -57,7 +57,7 @@ func (m *Metadata) UnmarshalToken(tok *xmltokenizer.Tokenizer, se *xmltokenizer.
 				return fmt.Errorf("link: %w", err)
 			}
 		case "time":
-			m.Time, err = time.Parse(time.RFC3339, string(token.CharData))
+			m.Time, err = time.Parse(time.RFC3339, string(token.Data))
 			if err != nil {
 				return fmt.Errorf("time: %w", err)
 			}
@@ -142,7 +142,7 @@ func (a *Author) UnmarshalToken(tok *xmltokenizer.Tokenizer, se *xmltokenizer.To
 
 		switch string(token.Name.Local) {
 		case "name":
-			a.Name = string(token.CharData)
+			a.Name = string(token.Data)
 		case "link":
 			a.Link = new(Link)
 			se := xmltokenizer.GetToken().Copy(token)
@@ -226,9 +226,9 @@ func (a *Link) UnmarshalToken(tok *xmltokenizer.Tokenizer, se *xmltokenizer.Toke
 
 		switch string(token.Name.Local) {
 		case "text":
-			a.Text = string(token.CharData)
+			a.Text = string(token.Data)
 		case "type":
-			a.Type = string(token.CharData)
+			a.Type = string(token.Data)
 		}
 	}
 

--- a/internal/gpx/schema/track.go
+++ b/internal/gpx/schema/track.go
@@ -36,9 +36,9 @@ func (t *Track) UnmarshalToken(tok *xmltokenizer.Tokenizer, se *xmltokenizer.Tok
 
 		switch string(token.Name.Local) {
 		case "name":
-			t.Name = string(token.CharData)
+			t.Name = string(token.Data)
 		case "type":
-			t.Type = string(token.CharData)
+			t.Type = string(token.Data)
 		case "trkseg":
 			var trkseg TrackSegment
 			se := xmltokenizer.GetToken().Copy(token)
@@ -216,12 +216,12 @@ func (w *Waypoint) UnmarshalToken(tok *xmltokenizer.Tokenizer, se *xmltokenizer.
 
 		switch string(token.Name.Local) {
 		case "ele":
-			w.Ele, err = strconv.ParseFloat(string(token.CharData), 64)
+			w.Ele, err = strconv.ParseFloat(string(token.Data), 64)
 			if err != nil {
 				return fmt.Errorf("ele: %w", err)
 			}
 		case "time":
-			w.Time, err = time.Parse(time.RFC3339, string(token.CharData))
+			w.Time, err = time.Parse(time.RFC3339, string(token.Data))
 			if err != nil {
 				return fmt.Errorf("time: %w", err)
 			}

--- a/internal/xlsx/schema/sheet.go
+++ b/internal/xlsx/schema/sheet.go
@@ -142,9 +142,9 @@ func (c *Cell) UnmarshalToken(tok *xmltokenizer.Tokenizer, se *xmltokenizer.Toke
 
 		switch string(token.Name.Local) {
 		case "v":
-			c.Value = string(token.CharData)
+			c.Value = string(token.Data)
 		case "t":
-			c.InlineString = string(token.CharData)
+			c.InlineString = string(token.Data)
 		}
 	}
 

--- a/testdata/cdata.xml
+++ b/testdata/cdata.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<data>
+  <![CDATA[ text ]]>
+</data>

--- a/testdata/copyright_header.xml
+++ b/testdata/copyright_header.xml
@@ -1,0 +1,4 @@
+<!-- 
+  Copyright 2024 Example Licence Authors.
+-->
+<?xml version="1.0" encoding="UTF-8"?>

--- a/testdata/long_comment_token.xml
+++ b/testdata/long_comment_token.xml
@@ -1,0 +1,63 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- 
+
+Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec commodo sed lacus non semper.
+Maecenas rhoncus elementum nisl, ut facilisis diam faucibus tristique. Vivamus in risus at odio
+tincidunt iaculis id gravida ante. Phasellus sed est interdum, pretium neque vitae, semper sem.
+Nulla ac massa nisl. Etiam sit amet mi nisi. Fusce felis nibh, imperdiet at justo at, condimentum
+elementum justo. Duis risus neque, viverra quis tincidunt at, egestas eget arcu. Quisque vestibulum
+odio at hendrerit mattis.
+
+Nulla elementum consequat pharetra. Orci varius natoque penatibus et magnis dis parturient montes,
+nascetur ridiculus mus. Praesent venenatis urna ut nunc dictum feugiat. Suspendisse nec eros quis
+neque interdum porttitor vel non urna. Donec sollicitudin ipsum a lorem commodo mattis. Nulla nec
+massa orci. Proin ac enim ut magna vehicula tristique. Praesent dolor nunc, faucibus id magna non,
+molestie viverra nulla. Donec ipsum orci, pellentesque ut dui eget, iaculis gravida tortor. Aenean
+ut sapien ac massa vulputate tincidunt eget et sapien. Donec ullamcorper posuere nunc sed varius.
+Suspendisse at feugiat metus, scelerisque iaculis neque. Quisque congue, risus laoreet tempor
+faucibus, lectus felis maximus ex, a gravida nisi justo sit amet ex. Aenean tristique velit
+elementum, cursus augue a, suscipit turpis.
+
+Integer eu aliquet nisi. Integer viverra iaculis enim vel congue. Pellentesque ullamcorper neque
+vitae auctor egestas. Integer ipsum elit, aliquam quis justo vel, malesuada convallis tortor.
+Praesent efficitur erat a suscipit hendrerit. Nulla tempor id est porttitor aliquam. Donec ut diam
+vitae lectus laoreet porttitor nec vitae leo. Curabitur sed ante vitae ante convallis dignissim sed
+aliquam lorem. Vestibulum ut eleifend ex. Fusce erat tellus, rhoncus ut ultrices vel, euismod sit
+amet urna.
+
+In dolor enim, placerat cursus suscipit ac, pharetra ultrices mi. Nam dapibus lectus vel leo
+aliquam luctus. Curabitur vitae ligula egestas, gravida dolor id, venenatis magna. Ut porta a magna
+vel maximus. Etiam faucibus pulvinar finibus. Fusce a est hendrerit, accumsan massa at, bibendum
+mauris. Mauris lacinia, lorem vitae pellentesque bibendum, libero neque dapibus odio, ut molestie
+risus ligula ut turpis. Aliquam at arcu auctor, finibus orci eget, consequat urna. Nulla vestibulum
+libero elementum magna feugiat euismod. Donec aliquet elit sit amet orci luctus, posuere feugiat
+nisi eleifend.
+
+Pellentesque id blandit nibh. Aenean et nulla et ipsum hendrerit cursus sit amet ut arcu. Nam a
+orci nunc. In nec dolor suscipit, imperdiet mi at, vestibulum lacus. Fusce feugiat, sapien sit amet
+pharetra consectetur, lacus nulla malesuada velit, in posuere dui enim vitae odio. Proin accumsan
+nisl eget libero maximus convallis. Mauris vitae ex dolor. Praesent vehicula feugiat leo, ut
+facilisis tellus accumsan eu. Aenean elementum, lacus eu gravida euismod, justo tellus congue odio,
+et suscipit quam sem in tortor. Quisque consectetur eros lorem, at feugiat eros hendrerit eget. Sed
+imperdiet, nisl nec aliquam ultricies, massa metus mollis velit, nec maximus sapien elit id ipsum.
+In ullamcorper ante ac dui condimentum, sit amet aliquam quam dignissim. Pellentesque et gravida
+nisi, nec lobortis leo. 
+
+Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec commodo sed lacus non semper.
+Maecenas rhoncus elementum nisl, ut facilisis diam faucibus tristique. Vivamus in risus at odio
+tincidunt iaculis id gravida ante. Phasellus sed est interdum, pretium neque vitae, semper sem.
+Nulla ac massa nisl. Etiam sit amet mi nisi. Fusce felis nibh, imperdiet at justo at, condimentum
+elementum justo. Duis risus neque, viverra quis tincidunt at, egestas eget arcu. Quisque vestibulum
+odio at hendrerit mattis.
+
+Nulla elementum consequat pharetra. Orci varius natoque penatibus et magnis dis parturient montes,
+nascetur ridiculus mus. Praesent venenatis urna ut nunc dictum feugiat. Suspendisse nec eros quis
+neque interdum porttitor vel non urna. Donec sollicitudin ipsum a lorem commodo mattis. Nulla nec
+massa orci. Proin ac enim ut magna vehicula tristique. Praesent dolor nunc, faucibus id magna non,
+molestie viverra nulla. Donec ipsum orci, pellentesque ut dui eget, iaculis gravida tortor. Aenean
+ut sapien ac massa vulputate tincidunt eget et sapien. Donec ullamcorper posuere nunc sed varius.
+Suspendisse at feugiat metus, scelerisque iaculis neque. Quisque congue, risus laoreet tempor
+faucibus, lectus felis maximus ex, a gravida nisi justo sit amet ex. Aenean tristique velit
+elementum, cursus augue a, suscipit turpis.
+
+-->

--- a/token.go
+++ b/token.go
@@ -17,11 +17,11 @@ func PutToken(t *Token) { pool.Put(t) }
 //   - <name attr="value" attr="value"/>
 //   - </name>
 //   - <!-- comment -->
-//   - <![CDATA[ chardata ]]>
+//   - <![CDATA[ some text ]]>
 type Token struct {
-	Name        Name   // Name: ProcInst: "?xml", StartElement: "name", EndElement: "/name".
+	Name        Name   // Name: ProcInst: "?xml", StartElement: "name", EndElement: "/name", Comment: "<!--", CDATA: "<![[CDATA", etc.
 	Attrs       []Attr // Attrs exist when len(Attrs) > 0.
-	CharData    []byte // CharData exist when len(CharData) > 0.
+	Data        []byte // Data could be a CharData, a comment, a CDATA, etc. Depends on identifier in Name.
 	SelfClosing bool   // True when tag end with "/>"" e.g. <c r="E3" s="1" /> instead of <c r="E3" s="1"></c>
 }
 
@@ -53,7 +53,7 @@ func (t *Token) Copy(src Token) *Token {
 	t.Name.Local = append(t.Name.Local[:0], src.Name.Local...)
 	t.Name.Full = append(t.Name.Full[:0], src.Name.Full...)
 	t.Attrs = append(t.Attrs[:0], src.Attrs...) // shallow copy
-	t.CharData = append(t.CharData[:0], src.CharData...)
+	t.Data = append(t.Data[:0], src.Data...)
 	t.SelfClosing = src.SelfClosing
 	return t
 }

--- a/token_test.go
+++ b/token_test.go
@@ -135,7 +135,7 @@ func TestCopy(t *testing.T) {
 			},
 			Value: []byte("bpm"),
 		}},
-		CharData: []byte("70"),
+		Data: []byte("70"),
 	}
 
 	var t2 xmltokenizer.Token
@@ -146,7 +146,7 @@ func TestCopy(t *testing.T) {
 	}
 
 	t2.Name.Full = append(t2.Name.Full[:0], "asd"...)
-	t2.CharData = append(t2.CharData[:0], "60"...)
+	t2.Data = append(t2.Data[:0], "60"...)
 	if diff := cmp.Diff(t2, t1); diff == "" {
 		t.Fatalf("expected different, got same")
 	}

--- a/tokenizer_internal_test.go
+++ b/tokenizer_internal_test.go
@@ -1,0 +1,113 @@
+package xmltokenizer
+
+import (
+	"errors"
+	"io"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+)
+
+func TestOptions(t *testing.T) {
+	tt := []struct {
+		name            string
+		options         []Option
+		expectedOptions options
+	}{
+		{
+			name:            "defaultOptions",
+			expectedOptions: defaultOptions(),
+		},
+		{
+			name: "less than 0",
+			options: []Option{
+				WithReadBufferSize(-1),
+				WithAttrBufferSize(-1),
+				WithAutoGrowBufferMaxLimitSize(-1),
+			},
+			expectedOptions: options{
+				readBufferSize:             defaultReadBufferSize,
+				autoGrowBufferMaxLimitSize: autoGrowBufferMaxLimitSize,
+				attrsBufferSize:            defaultAttrsBufferSize,
+			},
+		},
+		{
+			name: "readBufferSize > maxLimitGrowBufferSize",
+			options: []Option{
+				WithReadBufferSize(4 << 10),
+				WithAutoGrowBufferMaxLimitSize(1 << 10),
+			},
+			expectedOptions: options{
+				readBufferSize:             4 << 10,
+				autoGrowBufferMaxLimitSize: 4 << 10,
+				attrsBufferSize:            defaultAttrsBufferSize,
+			},
+		},
+	}
+
+	for _, tc := range tt {
+		t.Run(tc.name, func(t *testing.T) {
+			tok := New(nil, tc.options...)
+			if diff := cmp.Diff(tok.options, tc.expectedOptions,
+				cmp.AllowUnexported(options{}),
+			); diff != "" {
+				t.Fatal(diff)
+			}
+		})
+	}
+}
+
+func TestAutoGrowBuffer(t *testing.T) {
+	tt := []struct {
+		name     string
+		filename string
+		opts     []Option
+		err      error
+	}{
+		{
+			name:     "grow buffer with alloc",
+			filename: "long_comment_token.xml",
+			opts: []Option{
+				WithReadBufferSize(5),
+			},
+			err: nil,
+		},
+		{
+			name:     "grow buffer exceed max limit",
+			filename: "long_comment_token.xml",
+			opts: []Option{
+				WithReadBufferSize(5),
+				WithAutoGrowBufferMaxLimitSize(5),
+			},
+			err: errAutoGrowBufferExceedMaxLimit,
+		},
+	}
+
+	for _, tc := range tt {
+		t.Run(tc.name, func(t *testing.T) {
+			f, err := os.Open(filepath.Join("testdata", tc.filename))
+			if err != nil {
+				panic(err)
+			}
+			defer f.Close()
+
+			tok := New(f, tc.opts...)
+			for {
+				_, err = tok.Token()
+				if err == io.EOF {
+					err = nil
+					break
+				}
+				if err != nil {
+					break
+				}
+			}
+
+			if !errors.Is(err, tc.err) {
+				t.Fatalf("expected error: %v, got: %v", tc.err, err)
+			}
+		})
+	}
+}


### PR DESCRIPTION
- Fix parsing `<!-- comment -->` and `<![CDATA[ some text ]]>` was not properly parsed.
- Implement max limit to auto grow buffer (grow by alloc) as a safeguard. This is crucial when handle XML file that contains abnormally long token or accidentally parsing non-XML file that may cause the buffer to grow unexpectedly. Default max limit 1 MB (should be enough to handle most cases) and it's configurable.