### PR TITLE
fix: parsing CDATA that has a markup

### DIFF
--- a/testdata/cdata.xml
+++ b/testdata/cdata.xml
@@ -1,4 +1,14 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<data>
-  <![CDATA[ text ]]>
-</data>
+<content>
+  <data>
+    <![CDATA[ text ]]>
+  </data>
+  <data>
+    <![CDATA[<element>text</element>]]>
+  </data>
+  <data>
+    <![CDATA[
+      <element>text</element>
+    ]]>
+  </data>
+</content>

--- a/testdata/cdata_clrf.xml
+++ b/testdata/cdata_clrf.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<content>
+  <data>
+    <![CDATA[ text ]]>
+  </data>
+  <data>
+    <![CDATA[<element>text</element>]]>
+  </data>
+  <data>
+    <![CDATA[
+      <element>text</element>
+    ]]>
+  </data>
+</content>

--- a/tokenizer.go
+++ b/tokenizer.go
@@ -185,7 +185,6 @@ func (t *Tokenizer) RawToken() (b []byte, err error) {
 				}
 				if k < len(prefix) {
 					if t.buf[i] != prefix[k] {
-						k = 0
 						break
 					}
 					k++
@@ -216,7 +215,7 @@ func (t *Tokenizer) RawToken() (b []byte, err error) {
 				if t.buf[i] == '<' {
 					pos = i - 1
 					// Might be in the form of <![CDATA[ CharData ]]>
-					const prefix = "<![CDATA["
+					const prefix, suffix = "<![CDATA[", "]]>"
 					var k int = 1
 					for j := i + 1; ; j++ {
 						if j >= t.last {
@@ -235,7 +234,9 @@ func (t *Tokenizer) RawToken() (b []byte, err error) {
 							k++
 							continue
 						}
-						if t.buf[j] == '>' {
+						xx := string(t.buf[off : j+1])
+						_ = xx
+						if t.buf[j] == '>' && string(t.buf[j-2:j+1]) == suffix {
 							pos = j
 							break
 						}
@@ -384,11 +385,12 @@ func trim(b []byte) []byte {
 
 func trimPrefix(b []byte) []byte {
 	var start int
-	for i := range b {
+	for i := 0; i < len(b); i++ {
 		switch b[i] {
 		case '\r':
 			if i+1 < len(b) && b[i+1] == '\n' {
 				start += 2
+				i++
 			}
 		case '\n', ' ':
 			start++

--- a/tokenizer_test.go
+++ b/tokenizer_test.go
@@ -26,12 +26,44 @@ func TestSmallXML(t *testing.T) {
 	}{
 		{filename: "cdata.xml", expecteds: []xmltokenizer.Token{
 			tokenHeader,
+			{Name: xmltokenizer.Name{Local: []byte("content"), Full: []byte("content")}},
 			{
 				Name: xmltokenizer.Name{Local: []byte("data"), Full: []byte("data")},
 				Data: []byte("text"),
 			},
-			{Name: xmltokenizer.Name{Local: []byte("/data"), Full: []byte("/data")}}},
-		},
+			{Name: xmltokenizer.Name{Local: []byte("/data"), Full: []byte("/data")}},
+			{
+				Name: xmltokenizer.Name{Local: []byte("data"), Full: []byte("data")},
+				Data: []byte("<element>text</element>"),
+			},
+			{Name: xmltokenizer.Name{Local: []byte("/data"), Full: []byte("/data")}},
+			{
+				Name: xmltokenizer.Name{Local: []byte("data"), Full: []byte("data")},
+				Data: []byte("<element>text</element>"),
+			},
+			{Name: xmltokenizer.Name{Local: []byte("/data"), Full: []byte("/data")}},
+			{Name: xmltokenizer.Name{Local: []byte("/content"), Full: []byte("/content")}},
+		}},
+		{filename: "cdata_clrf.xml", expecteds: []xmltokenizer.Token{
+			tokenHeader,
+			{Name: xmltokenizer.Name{Local: []byte("content"), Full: []byte("content")}},
+			{
+				Name: xmltokenizer.Name{Local: []byte("data"), Full: []byte("data")},
+				Data: []byte("text"),
+			},
+			{Name: xmltokenizer.Name{Local: []byte("/data"), Full: []byte("/data")}},
+			{
+				Name: xmltokenizer.Name{Local: []byte("data"), Full: []byte("data")},
+				Data: []byte("<element>text</element>"),
+			},
+			{Name: xmltokenizer.Name{Local: []byte("/data"), Full: []byte("/data")}},
+			{
+				Name: xmltokenizer.Name{Local: []byte("data"), Full: []byte("data")},
+				Data: []byte("<element>text</element>"),
+			},
+			{Name: xmltokenizer.Name{Local: []byte("/data"), Full: []byte("/data")}},
+			{Name: xmltokenizer.Name{Local: []byte("/content"), Full: []byte("/content")}},
+		}},
 		{filename: "self_closing.xml", expecteds: []xmltokenizer.Token{
 			tokenHeader,
 			{Name: xmltokenizer.Name{Local: []byte("a"), Full: []byte("a")}, SelfClosing: true},


### PR DESCRIPTION
A CDATA section is typically used to embed an XML document within another XML document: `<![CDATA[<element>text</element>]]>`, the parser should be able to parse `<element>text</element>` as the CharData.

Ref: https://www.ibm.com/docs/en/integration-bus/10.0?topic=messages-xmlnsc-working-cdata