### PR TITLE
Refactor internal/gpx and internal/xlsx to abstract I/O

### DIFF
--- a/benchmark_test.go
+++ b/benchmark_test.go
@@ -119,14 +119,19 @@ func BenchmarkUnmarshalXLSX(b *testing.B) {
 	path := filepath.Join("testdata", "xlsx_sheet1.xml")
 	name := strings.TrimPrefix(path, "testdata/")
 
+	data, err := os.ReadFile(path)
+	if err != nil {
+		panic(err)
+	}
+
 	b.Run(fmt.Sprintf("stdlib.xml:%q", name), func(b *testing.B) {
 		for i := 0; i < b.N; i++ {
-			_, _ = xlsx.UnmarshalWithStdlibXML(path)
+			_, _ = xlsx.UnmarshalWithStdlibXML(bytes.NewReader(data))
 		}
 	})
 	b.Run(fmt.Sprintf("xmltokenizer:%q", name), func(b *testing.B) {
 		for i := 0; i < b.N; i++ {
-			_, _ = xlsx.UnmarshalWithXMLTokenizer(path)
+			_, _ = xlsx.UnmarshalWithXMLTokenizer(bytes.NewReader(data))
 		}
 	})
 }

--- a/benchmark_test.go
+++ b/benchmark_test.go
@@ -1,6 +1,7 @@
 package xmltokenizer_test
 
 import (
+	"bytes"
 	"encoding/xml"
 	"fmt"
 	"io"
@@ -94,14 +95,19 @@ func BenchmarkUnmarshalGPX(b *testing.B) {
 
 		name := strings.TrimPrefix(path, "testdata/")
 
+		data, err := os.ReadFile(path)
+		if err != nil {
+			panic(err)
+		}
+
 		b.Run(fmt.Sprintf("stdlib.xml:%q", name), func(b *testing.B) {
 			for i := 0; i < b.N; i++ {
-				_, _ = gpx.UnmarshalWithStdlibXML(path)
+				_, _ = gpx.UnmarshalWithStdlibXML(bytes.NewReader(data))
 			}
 		})
 		b.Run(fmt.Sprintf("xmltokenizer:%q", name), func(b *testing.B) {
 			for i := 0; i < b.N; i++ {
-				_, _ = gpx.UnmarshalWithXMLTokenizer(path)
+				_, _ = gpx.UnmarshalWithXMLTokenizer(bytes.NewReader(data))
 			}
 		})
 

--- a/internal/gpx/unmarshal.go
+++ b/internal/gpx/unmarshal.go
@@ -3,19 +3,12 @@ package gpx
 import (
 	"encoding/xml"
 	"io"
-	"os"
 
 	"github.com/muktihari/xmltokenizer"
 	"github.com/muktihari/xmltokenizer/internal/gpx/schema"
 )
 
-func UnmarshalWithXMLTokenizer(path string) (schema.GPX, error) {
-	f, err := os.Open(path)
-	if err != nil {
-		panic(err)
-	}
-	defer f.Close()
-
+func UnmarshalWithXMLTokenizer(f io.Reader) (schema.GPX, error) {
 	tok := xmltokenizer.New(f)
 	var gpx schema.GPX
 loop:
@@ -43,13 +36,7 @@ loop:
 	return gpx, nil
 }
 
-func UnmarshalWithStdlibXML(path string) (schema.GPX, error) {
-	f, err := os.Open(path)
-	if err != nil {
-		panic(err)
-	}
-	defer f.Close()
-
+func UnmarshalWithStdlibXML(f io.Reader) (schema.GPX, error) {
 	dec := xml.NewDecoder(f)
 	var gpx schema.GPX
 loop:

--- a/internal/xlsx/unmarshal.go
+++ b/internal/xlsx/unmarshal.go
@@ -3,20 +3,13 @@ package xlsx
 import (
 	"encoding/xml"
 	"io"
-	"os"
 
 	"github.com/muktihari/xmltokenizer"
 	"github.com/muktihari/xmltokenizer/internal/xlsx/schema"
 )
 
-func UnmarshalWithXMLTokenizer(path string) (schema.SheetData, error) {
-	f, err := os.Open(path)
-	if err != nil {
-		panic(err)
-	}
-	defer f.Close()
-
-	tok := xmltokenizer.New(f)
+func UnmarshalWithXMLTokenizer(r io.Reader) (schema.SheetData, error) {
+	tok := xmltokenizer.New(r)
 	var sheetData schema.SheetData
 loop:
 	for {
@@ -43,14 +36,8 @@ loop:
 	return sheetData, nil
 }
 
-func UnmarshalWithStdlibXML(path string) (schema.SheetData, error) {
-	f, err := os.Open(path)
-	if err != nil {
-		panic(err)
-	}
-	defer f.Close()
-
-	dec := xml.NewDecoder(f)
+func UnmarshalWithStdlibXML(r io.Reader) (schema.SheetData, error) {
+	dec := xml.NewDecoder(r)
 	var sheetData schema.SheetData
 	for {
 		token, err := dec.Token()

--- a/tokenizer_test.go
+++ b/tokenizer_test.go
@@ -324,12 +324,17 @@ func TestTokenOnGPXFiles(t *testing.T) {
 				return
 			}
 
-			gpx1, err := gpx.UnmarshalWithXMLTokenizer(path)
+			data, err := os.ReadFile(path)
+			if err != nil {
+				t.Skip(err)
+			}
+
+			gpx1, err := gpx.UnmarshalWithXMLTokenizer(bytes.NewReader(data))
 			if err != nil {
 				t.Fatalf("xmltokenizer: %v", err)
 			}
 
-			gpx2, err := gpx.UnmarshalWithStdlibXML(path)
+			gpx2, err := gpx.UnmarshalWithStdlibXML(bytes.NewReader(data))
 			if err != nil {
 				t.Fatalf("xml: %v", err)
 			}

--- a/tokenizer_test.go
+++ b/tokenizer_test.go
@@ -355,11 +355,16 @@ func TestTokenOnGPXFiles(t *testing.T) {
 func TestTokenOnXLSXFiles(t *testing.T) {
 	path := filepath.Join("testdata", "xlsx_sheet1.xml")
 
-	sheet1, err := xlsx.UnmarshalWithXMLTokenizer(path)
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Skip(err)
+	}
+
+	sheet1, err := xlsx.UnmarshalWithXMLTokenizer(bytes.NewReader(data))
 	if err != nil {
 		t.Fatalf("xmltokenizer: %v", err)
 	}
-	sheet2, err := xlsx.UnmarshalWithStdlibXML(path)
+	sheet2, err := xlsx.UnmarshalWithStdlibXML(bytes.NewReader(data))
 	if err != nil {
 		t.Fatalf("xml: %v", err)
 	}
@@ -405,7 +410,13 @@ loop:
 		}
 	}
 
-	sheetData2, err := xlsx.UnmarshalWithStdlibXML(path)
+	f2, err := os.Open(path)
+	if err != nil {
+		panic(err)
+	}
+	defer f2.Close()
+
+	sheetData2, err := xlsx.UnmarshalWithStdlibXML(f2)
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
Use `io.Reader` instead of `path string` as argument to functions `UnmarshalWith*` in packages `internal/gpx` and `internal/xlsx`.

The guiding principle of this refactor is similar to #17.