### PR TITLE
fix: ensure tokenizer can handle equals in attrs (#29)

### DIFF
--- a/tokenizer.go
+++ b/tokenizer.go
@@ -340,9 +340,11 @@ func (t *Tokenizer) consumeAttrs(b []byte) []byte {
 				pos = i + 1
 			}
 		case '=':
-			local = trim(b[pos:i])
-			full = trim(b[fullpos:i])
-			pos = i + 1
+			if !inquote {
+				local = trim(b[pos:i])
+				full = trim(b[fullpos:i])
+				pos = i + 1
+			}
 		case '"':
 			inquote = !inquote
 			if !inquote {

--- a/tokenizer_test.go
+++ b/tokenizer_test.go
@@ -143,6 +143,30 @@ func TestTokenWithInmemXML(t *testing.T) {
 				{Name: xmltokenizer.Name{Local: []byte("a"), Full: []byte("a")}, IsEndElement: true},
 			},
 		},
+		{
+			name: "unexpected equals in attr name",
+			xml:  "<?xml version=\"1.0\" encoding=\"UTF-8\"?><Image URL=\"https://test.com/my-url-ending-in-=\" URL2=\"https://ok.com\"/>",
+			expecteds: []xmltokenizer.Token{
+				{
+					Data:         []byte(`<?xml version="1.0" encoding="UTF-8"?>`),
+					SelfClosing:  true,
+					IsEndElement: false,
+				},
+				{Name: xmltokenizer.Name{Local: []byte("Image"), Full: []byte("Image")},
+					Attrs: []xmltokenizer.Attr{
+						{
+							Name:  xmltokenizer.Name{Local: []uint8("URL"), Full: []uint8("URL")},
+							Value: []uint8("https://test.com/my-url-ending-in-="),
+						},
+						{
+							Name:  xmltokenizer.Name{Local: []uint8("URL2"), Full: []uint8("URL2")},
+							Value: []uint8("https://ok.com"),
+						},
+					},
+					SelfClosing: true,
+				},
+			},
+		},
 	}
 
 	for i, tc := range tt {


### PR DESCRIPTION
Closes (#29).

When a '=' was found within an attribute, it would increment the position unnecessarily, causing an out-of-bounds panic when performing: ```Value: trim(b[pos+1 : i])```.

We should instead only do this when we are ```!inquote```.

Test added to cover this.
