### PR TITLE
Fixes for angle brackets, forward slash, tabs

### DIFF
--- a/tokenizer.go
+++ b/tokenizer.go
@@ -174,6 +174,9 @@ func (t *Tokenizer) RawToken() (b []byte, err error) {
 		case '<':
 			if openclose == 0 {
 				pivot = pos
+			} else if d := pos - pivot; d >= 3 && string(t.buf[pivot+1:pivot+4]) == "!--" {
+				// Inside a comment
+				break
 			}
 			openclose++
 		case '>':

--- a/tokenizer.go
+++ b/tokenizer.go
@@ -326,7 +326,7 @@ func (t *Tokenizer) consumeTagName(b []byte) []byte {
 		case ':':
 			t.token.Name.Prefix = trim(b[pos:i])
 			pos = i + 1
-		case '>', ' ': // e.g. <gpx>, <trkpt lat="-7.1872750" lon="110.3450230">
+		case '>', ' ', '\t', '\r', '\n': // e.g. <gpx>, <trkpt lat="-7.1872750" lon="110.3450230">
 			if b[i] == '>' && b[i-1] == '/' { // In case we encounter <name/>
 				i--
 			}

--- a/tokenizer.go
+++ b/tokenizer.go
@@ -331,34 +331,35 @@ func (t *Tokenizer) consumeTagName(b []byte) []byte {
 func (t *Tokenizer) consumeAttrs(b []byte) []byte {
 	var prefix, local, full []byte
 	var pos, fullpos int
-	var inquote bool
-	for i := range b {
+	for i := 0; i != len(b); i++ {
 		switch b[i] {
 		case ':':
-			if !inquote {
-				prefix = trim(b[pos:i])
-				pos = i + 1
-			}
+			prefix = trim(b[pos:i])
+			pos = i + 1
 		case '=':
-			if !inquote {
-				local = trim(b[pos:i])
-				full = trim(b[fullpos:i])
-				pos = i + 1
-			}
+			local = trim(b[pos:i])
+			full = trim(b[fullpos:i])
+			pos = i + 1
 		case '"':
-			inquote = !inquote
-			if !inquote {
-				if len(full) == 0 { // Ignore malformed attr
-					continue
+			for {
+				i++
+				if i+1 == len(b) {
+					return b
 				}
-				t.token.Attrs = append(t.token.Attrs, Attr{
-					Name:  Name{Prefix: prefix, Local: local, Full: full},
-					Value: trim(b[pos+1 : i]),
-				})
-				prefix, local, full = nil, nil, nil
-				pos = i + 1
-				fullpos = i + 1
+				if b[i] == '"' {
+					break
+				}
 			}
+			if len(full) == 0 { // Ignore malformed attr
+				continue
+			}
+			t.token.Attrs = append(t.token.Attrs, Attr{
+				Name:  Name{Prefix: prefix, Local: local, Full: full},
+				Value: trim(b[pos+1 : i]),
+			})
+			prefix, local, full = nil, nil, nil
+			pos = i + 1
+			fullpos = i + 1
 		case '/':
 			t.token.SelfClosing = true
 		case '>':

--- a/tokenizer.go
+++ b/tokenizer.go
@@ -177,6 +177,13 @@ func (t *Tokenizer) RawToken() (b []byte, err error) {
 			}
 			openclose++
 		case '>':
+			if d := pos - pivot; d >= 3 && string(t.buf[pivot+1:pivot+4]) == "!--" {
+				// Inside a comment
+				if d < 5 || string(t.buf[pos-2:pos]) != "--" {
+					// This > is not part of the closing -->
+					break
+				}
+			}
 			if openclose--; openclose != 0 {
 				break
 			}

--- a/tokenizer_test.go
+++ b/tokenizer_test.go
@@ -167,6 +167,36 @@ func TestTokenWithInmemXML(t *testing.T) {
 				},
 			},
 		},
+		{
+			name: "slash inside attribute value",
+			xml:  `<sample path="foo/bar/baz">`,
+			expecteds: []xmltokenizer.Token{
+				{
+					Name: xmltokenizer.Name{Local: []byte("sample"), Full: []byte("sample")},
+					Attrs: []xmltokenizer.Attr{
+						{
+							Name:  xmltokenizer.Name{Local: []uint8("path"), Full: []uint8("path")},
+							Value: []uint8("foo/bar/baz"),
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "right angle bracket inside attribute value",
+			xml:  `<sample path="foo>bar>baz">`,
+			expecteds: []xmltokenizer.Token{
+				{
+					Name: xmltokenizer.Name{Local: []byte("sample"), Full: []byte("sample")},
+					Attrs: []xmltokenizer.Attr{
+						{
+							Name:  xmltokenizer.Name{Local: []uint8("path"), Full: []uint8("path")},
+							Value: []uint8("foo>bar>baz"),
+						},
+					},
+				},
+			},
+		},
 	}
 
 	for i, tc := range tt {

--- a/tokenizer_test.go
+++ b/tokenizer_test.go
@@ -197,6 +197,20 @@ func TestTokenWithInmemXML(t *testing.T) {
 				},
 			},
 		},
+		{
+			name: "right angle bracket inside comment",
+			xml:  `<!-->--><!-- foo>bar>baz -->`,
+			expecteds: []xmltokenizer.Token{
+				{
+					Data:        []byte(`<!-->-->`),
+					SelfClosing: true,
+				},
+				{
+					Data:        []byte(`<!-- foo>bar>baz -->`),
+					SelfClosing: true,
+				},
+			},
+		},
 	}
 
 	for i, tc := range tt {

--- a/tokenizer_test.go
+++ b/tokenizer_test.go
@@ -211,6 +211,20 @@ func TestTokenWithInmemXML(t *testing.T) {
 				},
 			},
 		},
+		{
+			name: "left angle bracket inside comment",
+			xml:  `<!--<--><!-- foo<bar<baz -->`,
+			expecteds: []xmltokenizer.Token{
+				{
+					Data:        []byte(`<!--<-->`),
+					SelfClosing: true,
+				},
+				{
+					Data:        []byte(`<!-- foo<bar<baz -->`),
+					SelfClosing: true,
+				},
+			},
+		},
 	}
 
 	for i, tc := range tt {

--- a/tokenizer_test.go
+++ b/tokenizer_test.go
@@ -225,6 +225,27 @@ func TestTokenWithInmemXML(t *testing.T) {
 				},
 			},
 		},
+		{
+			name: "tab inside element",
+			xml:  `<sample	foo="bar"/>`,
+			expecteds: []xmltokenizer.Token{
+				{
+					Name: xmltokenizer.Name{
+						Local: []uint8("sample"),
+						Full:  []uint8("sample"),
+					},
+					Attrs: []xmltokenizer.Attr{
+						{
+							Name: xmltokenizer.Name{
+								Local: []uint8("foo"),
+								Full:  []uint8("foo")},
+							Value: []uint8("bar"),
+						},
+					},
+					SelfClosing: true,
+				},
+			},
+		},
 	}
 
 	for i, tc := range tt {
@@ -237,6 +258,9 @@ func TestTokenWithInmemXML(t *testing.T) {
 			for i := 0; ; i++ {
 				token, err := tok.Token()
 				if err == io.EOF {
+					if i != len(tc.expecteds) {
+						t.Fatalf("expected %d tokens, got %d", len(tc.expecteds), i)
+					}
 					break
 				}
 				if err != nil {


### PR DESCRIPTION
Closes #35

1. The main changes are: ignoring `<` and `>` in `RawToken` if we're inside a comment
2. Handling whitespace other than ` ` when looking for the end of a node name
3. Ignoring `>` and `/` in `consumeAttrs` if inside attribute value

For (3), since it would have made every switch case branch on `inquote`, I opted to rearrange it to instead scan to the end of the attribute value in the `"` case (and eliminate `inquote`).

Also fix a small issue in the test harness where it would not fail if fewer tokens were returned than expected.

Can split it out into smaller PRs if preferred.