### PR TITLE
fix: handling whitespace after element name

### DIFF
--- a/tokenizer.go
+++ b/tokenizer.go
@@ -316,7 +316,7 @@ func (t *Tokenizer) consumeTagName(b []byte) []byte {
 		case ':':
 			t.token.Name.Prefix = trim(b[pos:i])
 			pos = i + 1
-		case '>', ' ': // e.g. <gpx>, <trkpt lat="-7.1872750" lon="110.3450230">
+		case '>', ' ', '\t', '\r', '\n': // e.g. <gpx>, <trkpt lat="-7.1872750" lon="110.3450230">
 			if b[i] == '>' && b[i-1] == '/' { // In case we encounter <name/>
 				i--
 			}

--- a/tokenizer_test.go
+++ b/tokenizer_test.go
@@ -167,6 +167,75 @@ func TestTokenWithInmemXML(t *testing.T) {
 				},
 			},
 		},
+		{
+			name: "tab after node name",
+			xml:  `<sample	foo="bar"/>`,
+			expecteds: []xmltokenizer.Token{
+				{
+					Name: xmltokenizer.Name{
+						Local: []uint8("sample"),
+						Full:  []uint8("sample"),
+					},
+					Attrs: []xmltokenizer.Attr{
+						{
+							Name: xmltokenizer.Name{
+								Local: []uint8("foo"),
+								Full:  []uint8("foo")},
+							Value: []uint8("bar"),
+						},
+					},
+					SelfClosing: true,
+				},
+			},
+		},
+		{
+			name: "tab after attribute value",
+			xml:  `<sample foo="bar"	/>`,
+			expecteds: []xmltokenizer.Token{
+				{
+					Name: xmltokenizer.Name{
+						Local: []uint8("sample"),
+						Full:  []uint8("sample"),
+					},
+					Attrs: []xmltokenizer.Attr{
+						{
+							Name: xmltokenizer.Name{
+								Local: []uint8("foo"),
+								Full:  []uint8("foo")},
+							Value: []uint8("bar"),
+						},
+					},
+					SelfClosing: true,
+				},
+			},
+		},
+		{
+			name: "tab between attributes",
+			xml:  `<sample foo="bar"	baz="quux"/>`,
+			expecteds: []xmltokenizer.Token{
+				{
+					Name: xmltokenizer.Name{
+						Local: []uint8("sample"),
+						Full:  []uint8("sample"),
+					},
+					Attrs: []xmltokenizer.Attr{
+						{
+							Name: xmltokenizer.Name{
+								Local: []uint8("foo"),
+								Full:  []uint8("foo")},
+							Value: []uint8("bar"),
+						},
+						{
+							Name: xmltokenizer.Name{
+								Local: []uint8("baz"),
+								Full:  []uint8("baz")},
+							Value: []uint8("quux"),
+						},
+					},
+					SelfClosing: true,
+				},
+			},
+		},
 	}
 
 	for i, tc := range tt {


### PR DESCRIPTION
Partly resolves #35.

This one fixes handling of non-space whitespace characters following the node name. The one I'm interested in is `\t`, but seems `\r` and `\n` should probably be treated the same, so added them too.