### PR TITLE
check number of returned elements in tokenizer_test

### DIFF
--- a/tokenizer_test.go
+++ b/tokenizer_test.go
@@ -179,6 +179,9 @@ func TestTokenWithInmemXML(t *testing.T) {
 			for i := 0; ; i++ {
 				token, err := tok.Token()
 				if err == io.EOF {
+					if i != len(tc.expecteds) {
+						t.Fatalf("expected %d tokens, got %d", len(tc.expecteds), i)
+					}
 					break
 				}
 				if err != nil {


### PR DESCRIPTION
Ensure the correct number of tokens are returned in the test harness. Not directly related to #35, just something I noticed while testing. Doesn't fail any of the existing tests.