### PR TITLE
fix: handling of forward-slash in attribute value

### DIFF
--- a/tokenizer.go
+++ b/tokenizer.go
@@ -331,7 +331,7 @@ func (t *Tokenizer) consumeTagName(b []byte) []byte {
 func (t *Tokenizer) consumeAttrs(b []byte) []byte {
 	var prefix, local, full []byte
 	var pos, fullpos int
-	for i := 0; i != len(b); i++ {
+	for i := 0; i < len(b); i++ {
 		switch b[i] {
 		case ':':
 			prefix = trim(b[pos:i])

--- a/tokenizer.go
+++ b/tokenizer.go
@@ -331,34 +331,35 @@ func (t *Tokenizer) consumeTagName(b []byte) []byte {
 func (t *Tokenizer) consumeAttrs(b []byte) []byte {
 	var prefix, local, full []byte
 	var pos, fullpos int
-	var inquote bool
-	for i := range b {
+	for i := 0; i != len(b); i++ {
 		switch b[i] {
 		case ':':
-			if !inquote {
-				prefix = trim(b[pos:i])
-				pos = i + 1
-			}
+			prefix = trim(b[pos:i])
+			pos = i + 1
 		case '=':
-			if !inquote {
-				local = trim(b[pos:i])
-				full = trim(b[fullpos:i])
-				pos = i + 1
-			}
+			local = trim(b[pos:i])
+			full = trim(b[fullpos:i])
+			pos = i + 1
 		case '"':
-			inquote = !inquote
-			if !inquote {
-				if len(full) == 0 { // Ignore malformed attr
-					continue
+			for {
+				i++
+				if i+1 == len(b) {
+					return b
 				}
-				t.token.Attrs = append(t.token.Attrs, Attr{
-					Name:  Name{Prefix: prefix, Local: local, Full: full},
-					Value: trim(b[pos+1 : i]),
-				})
-				prefix, local, full = nil, nil, nil
-				pos = i + 1
-				fullpos = i + 1
+				if b[i] == '"' {
+					break
+				}
 			}
+			if len(full) == 0 { // Ignore malformed attr
+				continue
+			}
+			t.token.Attrs = append(t.token.Attrs, Attr{
+				Name:  Name{Prefix: prefix, Local: local, Full: full},
+				Value: trim(b[pos+1 : i]),
+			})
+			prefix, local, full = nil, nil, nil
+			pos = i + 1
+			fullpos = i + 1
 		case '/':
 			t.token.SelfClosing = true
 		case '>':

--- a/tokenizer.go
+++ b/tokenizer.go
@@ -344,7 +344,7 @@ func (t *Tokenizer) consumeAttrs(b []byte) []byte {
 			for {
 				i++
 				if i+1 == len(b) {
-					return b
+					return nil
 				}
 				if b[i] == '"' {
 					break

--- a/tokenizer_test.go
+++ b/tokenizer_test.go
@@ -167,6 +167,21 @@ func TestTokenWithInmemXML(t *testing.T) {
 				},
 			},
 		},
+		{
+			name: "slash inside attribute value",
+			xml:  `<sample path="foo/bar/baz">`,
+			expecteds: []xmltokenizer.Token{
+				{
+					Name: xmltokenizer.Name{Local: []byte("sample"), Full: []byte("sample")},
+					Attrs: []xmltokenizer.Attr{
+						{
+							Name:  xmltokenizer.Name{Local: []uint8("path"), Full: []uint8("path")},
+							Value: []uint8("foo/bar/baz"),
+						},
+					},
+				},
+			},
+		},
 	}
 
 	for i, tc := range tt {


### PR DESCRIPTION
Partly resolves #35.

This one fixes handling of `/` inside attribute values. Previously these would mark the tag `SelfClosing`.

We scan to the closing quote in the `"` branch of `consumeAttrs`. This also allows the other branches to be simplified, because there is no `inquote` state variable to branch on each loop.