### PR TITLE
fixes for more edge cases in raw tokenizer

### DIFF
--- a/tokenizer_test.go
+++ b/tokenizer_test.go
@@ -251,6 +251,107 @@ func TestTokenWithInmemXML(t *testing.T) {
 				},
 			},
 		},
+		{
+			name: "right angle bracket inside attribute value",
+			xml:  `<sample path="foo>bar>baz">`,
+			expecteds: []xmltokenizer.Token{
+				{
+					Name: xmltokenizer.Name{Local: []byte("sample"), Full: []byte("sample")},
+					Attrs: []xmltokenizer.Attr{
+						{
+							Name:  xmltokenizer.Name{Local: []uint8("path"), Full: []uint8("path")},
+							Value: []uint8("foo>bar>baz"),
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "right angle bracket inside comment",
+			xml:  `<!-->--><!-- foo>bar>baz -->`,
+			expecteds: []xmltokenizer.Token{
+				{
+					Data:        []byte(`<!-->-->`),
+					SelfClosing: true,
+				},
+				{
+					Data:        []byte(`<!-- foo>bar>baz -->`),
+					SelfClosing: true,
+				},
+			},
+		},
+		{
+			name: "left angle bracket inside comment",
+			xml:  `<!--<--><!-- foo<bar<baz -->`,
+			expecteds: []xmltokenizer.Token{
+				{
+					Data:        []byte(`<!--<-->`),
+					SelfClosing: true,
+				},
+				{
+					Data:        []byte(`<!-- foo<bar<baz -->`),
+					SelfClosing: true,
+				},
+			},
+		},
+		{
+			name: "angle brackets in processing instruction",
+			xml:  `<?sample <foo> ?>`,
+			expecteds: []xmltokenizer.Token{
+				{
+					Data:        []uint8("<?sample <foo> ?>"),
+					SelfClosing: true,
+				},
+			},
+		},
+		{
+			name: "quote in processing instruction",
+			xml:  `<?sample " ?>`,
+			expecteds: []xmltokenizer.Token{
+				{
+					Data:        []uint8(`<?sample " ?>`),
+					SelfClosing: true,
+				},
+			},
+		},
+		{
+			name: "quoted right angle bracket in doctype",
+			xml:  `<!DOCTYPE ">" >`,
+			expecteds: []xmltokenizer.Token{
+				{
+					Data:        []uint8(`<!DOCTYPE ">" >`),
+					SelfClosing: true,
+				},
+			},
+		},
+		{
+			name: "commented angle brackets in doctype",
+			xml:  `<!DOCTYPE [ <!-- <foo> --> ] ><!DOCTYPE [ <!-- > --> ] ><!DOCTYPE [ <!-- < --> ] >`,
+			expecteds: []xmltokenizer.Token{
+				{
+					Data:        []uint8(`<!DOCTYPE [ <!-- <foo> --> ] >`),
+					SelfClosing: true,
+				},
+				{
+					Data:        []uint8(`<!DOCTYPE [ <!-- > --> ] >`),
+					SelfClosing: true,
+				},
+				{
+					Data:        []uint8(`<!DOCTYPE [ <!-- < --> ] >`),
+					SelfClosing: true,
+				},
+			},
+		},
+		{
+			name: "commented quote in doctype",
+			xml:  `<!DOCTYPE [ <!-- " --> ] >`,
+			expecteds: []xmltokenizer.Token{
+				{
+					Data:        []uint8(`<!DOCTYPE [ <!-- " --> ] >`),
+					SelfClosing: true,
+				},
+			},
+		},
 	}
 
 	for i, tc := range tt {


### PR DESCRIPTION
This PR closes out the remaining issues from #35.

As discussed:
* Left and right angle brackets within `<!--` and not part of the closing `-->` are considered part of the comment, and
* Right angle brackets are considered valid in attribute values (and no longer create a split in `RawToken`)

I also realized there was a similar issue with `<? ... ?>` tags, so made some fixes there too.

I had to rearrange `RawToken` a bit to get this to work efficiently. It now calls out to a new function `findTokenEnd` to locate the closing `>`, which returns -1 if it's not within the current buffer. The `findTokenEnd` has logic to skip past `>` that occur within comments or quoted values. It calls itself to skip past nested tags (such as may appear inside `<!DOCTYPE [ ... ] >`.

I took the opportunity to replace some of the byte-by-byte iteration with `bytes.IndexByte`, which gives a moderate performance boost in some of the benchmarks.