### PR TITLE
Handle single quote attributes

### DIFF
--- a/tokenizer.go
+++ b/tokenizer.go
@@ -340,13 +340,14 @@ func (t *Tokenizer) consumeAttrs(b []byte) []byte {
 			local = trim(b[pos:i])
 			full = trim(b[fullpos:i])
 			pos = i + 1
-		case '"':
+		case '"', '\'':
+			d := b[i]
 			for {
 				i++
 				if i+1 == len(b) {
 					return nil
 				}
-				if b[i] == '"' {
+				if b[i] == d {
 					break
 				}
 			}

--- a/tokenizer_test.go
+++ b/tokenizer_test.go
@@ -237,6 +237,33 @@ func TestTokenWithInmemXML(t *testing.T) {
 			},
 		},
 		{
+			name: "single quote attribute",
+			xml:  `<sample foo='bar' baz='"quux"'/>`,
+			expecteds: []xmltokenizer.Token{
+				{
+					Name: xmltokenizer.Name{
+						Local: []uint8("sample"),
+						Full:  []uint8("sample"),
+					},
+					Attrs: []xmltokenizer.Attr{
+						{
+							Name: xmltokenizer.Name{
+								Local: []uint8("foo"),
+								Full:  []uint8("foo")},
+							Value: []uint8("bar"),
+						},
+						{
+							Name: xmltokenizer.Name{
+								Local: []uint8("baz"),
+								Full:  []uint8("baz")},
+							Value: []uint8("\"quux\""),
+						},
+					},
+					SelfClosing: true,
+				},
+			},
+		},
+		{
 			name: "slash inside attribute value",
 			xml:  `<sample path="foo/bar/baz">`,
 			expecteds: []xmltokenizer.Token{


### PR DESCRIPTION
Some documents use single quotes for attributes. This handles both variants